### PR TITLE
IGNORE UPPERCASE OPENSTACK TOO FOR FUCKS SAKE

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -10,6 +10,8 @@ class OpenStack
     case m.message
     when /openstack/
       pass
+    when /OPENSTACK/
+      pass
     when /OpenStack/
       pass
     end


### PR DESCRIPTION
OBVIOUSLY you don't want jstir bothering you every time you mention an `OPENSTACK_*` environment variable. Jesus.
